### PR TITLE
updated testing-library/react to v14

### DIFF
--- a/my-app/package.json
+++ b/my-app/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@testing-library/jest-dom": "^5.16.5",
-    "@testing-library/react": "^13.4.0",
+    "@testing-library/react": "^14.0.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.4.0",
     "daisyui": "^3.1.5",


### PR DESCRIPTION
This update fixes a bug in the testing library, which causes a false warning message "An update to DropDownMultiPick inside a test was not wrapped in act(...)" to be shown even when using library functions that call act() internally.

The solution was found here:
https://stackoverflow.com/questions/76125899/the-infamous-a-test-was-not-wrapped-in-act

I tested the change on my working branch and found that it did indeed stop the warning from appearing during tests.